### PR TITLE
connect to postgres *before* server.ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ server.route({
     var select = escape('SELECT * FROM people WHERE (email = %L)', email);
     request.pg.client.query(select, function(err, result) {
       console.log(err, result);
-      request.pg.done(); // return the connection to the "pool"
-      // do what ever you want with the result
       return reply(result.rows[0]);
     })
   }
@@ -96,6 +94,9 @@ or why this is a *good idea*
 (*hard-coding values in your app is a really bad idea...*)  
 please see: https://github.com/dwyl/learn-environment-variables
 
+## *Q*: Don't We need to Close the Postgres Connection?
+
+***A***: No! The plugin handles closing the connection pool for you!
 
 
 ## *Implementation Detail*

--- a/index.js
+++ b/index.js
@@ -1,37 +1,45 @@
-var pg = require('pg');
 var assert = require('assert');
+
+var pg = require('pg');
 var internals = {};
 var pkg = require('./package.json');
+var _CON = []; // global
+var run_once = false;
+
+pg.connect(process.env.DATABASE_URL, function(err, client, done) {
+  assert(!err, pkg.name + 'ERROR Connecting')
+  _CON.push({ client: client, done: done});
+  return;
+});
 
 exports.register = function(server, options, next) {
   // if DATABASE_URL Environment Variable is unset halt the server.start
   assert(process.env.DATABASE_URL, 'Please set DATABASE_URL Env Variable');
-  // yes, this creates multiple connections, but aparently, that's OK...
-  var CON = [], run_once = false;
 
   server.ext('onPreAuth', function (request, reply) {
-    pg.connect(process.env.DATABASE_URL, function(err, client, done) {
-      assert(!err, pkg.name + 'ERROR Connecting')
-      server.log(['info', pkg.name], 'DB Connection Active');
-      CON.push({ client: client, done: done});
-      request.pg = {
-        client: client,
-        done: done
-      }
-      // each connection created is shut down when the server stops (e.g tests)
-      if(!run_once) {
-        run_once = true;
-        server.on('stop', function () { // only one server.on('stop') listener
-          CON.forEach(function (con) { // close all the connections
-            con.client.end();
-            con.done();
-          })
-          server.log(['info', pkg.name], 'DB Connection Closed');
-        });
-      }
-      reply.continue();
-    });
+    // each connection created is shut down when the server stops (e.g tests)
+    if(!run_once) {
+      run_once = true;
+      server.on('stop', function () { // only one server.on('stop') listener
+        _CON.forEach(function (con) { // close all the connections
+          con && con.client && con.client.readyForQuery && con.client.end();
+          con && con.done && con.done();
+        })
+        server.log(['info', pkg.name], 'DB Connection Closed');
+      });
+    }
+
+    request.pg = {
+      client: _CON[0].client,
+      done: _CON[0].done
+    }
+    reply.continue();
   });
+
+  // server.ext('onPostHandler', function (request, reply) {
+  //   request.pg && request.pg && request.pg.done();
+  //   reply.continue();
+  // });
 
   next();
 };

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "hapi-postgres-connection",
-  "version": "1.0.2",
+  "version": "2.0.1",
   "description": "A connection (pool) to PostgreSQL available anywhere in your hapi application",
   "main": "index.js",
   "scripts": {
+    "start":"PORT=8000 node test/server_example.js",
     "fast": "./node_modules/tape/bin/tape ./test/*.js",
     "test": "istanbul cover ./node_modules/tape/bin/tape ./test/*.js  | node_modules/tap-spec/bin/cmd.js"
   },
@@ -11,6 +12,7 @@
     "pg": "^4.5.1"
   },
   "devDependencies": {
+    "decache": "^3.0.5",
     "hapi": "^13.2.1",
     "istanbul": "^0.4.2",
     "pg-escape": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "fast": "./node_modules/tape/bin/tape ./test/*.js",
-    "test": "istanbul cover ./node_modules/tape/bin/tape ./test/test.js  | node_modules/tap-spec/bin/cmd.js"
+    "test": "istanbul cover ./node_modules/tape/bin/tape ./test/*.js  | node_modules/tap-spec/bin/cmd.js"
   },
   "dependencies": {
     "pg": "^4.5.1"

--- a/test/server_example.js
+++ b/test/server_example.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 var server = new Hapi.Server({ debug: { request: ['error'] } });
 
-server.connection();
+server.connection({ port: process.env.PORT });
 
 server.register({
   register: require('../index.js')
@@ -16,13 +16,21 @@ server.register({
 });
 
 server.route({
-  method: 'GET',
+  method: '*',
   path: '/',
   handler: function(request, reply) {
-    var email = 'test@test.net';
-    var select = escape('SELECT * FROM people WHERE (email = %L)', email);
-    request.pg.client.query(select, function(err, result) {
-      return reply(result.rows[0]);
+
+    var message = 'Hello World!';
+    var insert = escape('INSERT INTO logs (message) VALUES (%L)', message);
+    var q = 'SELECT * FROM logs ORDER BY log_timestamp DESC LIMIT 1;'
+    // var select = 'SELECT * FROM logs WHERE (log_id = 2)';
+    request.pg.client.query(insert, function(err, result) {
+      // console.log(err, result)
+      request.pg.client.query(q, function(err, result) {
+        // console.log(err, result.rows)
+        reply(result.rows[0]);
+        return;
+      })
     })
   }
 });

--- a/test/server_example.js
+++ b/test/server_example.js
@@ -22,8 +22,6 @@ server.route({
     var email = 'test@test.net';
     var select = escape('SELECT * FROM people WHERE (email = %L)', email);
     request.pg.client.query(select, function(err, result) {
-      request.pg.done();
-      // console.log(err, result);
       return reply(result.rows[0]);
     })
   }
@@ -37,11 +35,21 @@ server.route({
       request.payload.message);
     var select = 'SELECT * FROM logs WHERE (log_id = 2)';
     request.pg.client.query(insert, function(err, result) {
+      // console.log(err, result)
       request.pg.client.query(select, function(err, result) {
-        request.pg.done();
-        return reply(result.rows[0]);
+        // console.log(err, result.rows)
+        reply(result.rows[0]);
+        return;
       })
     })
+  }
+});
+
+server.route({
+  method: 'GET',
+  path: '/nopg',
+  handler: function(request, reply) {
+    return reply('nopg'); // does not make any PG queries
   }
 });
 

--- a/test/startup_failure.test.js
+++ b/test/startup_failure.test.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+var Hapi = require('hapi');
+
+/************************* TESTS ***************************/
+test("server.register plugin fails when DATABASE_URL undefined", function (t) {
+  // temporarily set process.env.DATABASE_URL to an Invalid url:
+  delete process.env.DATABASE_URL;
+  var server1 = new Hapi.Server();
+  server1.connection();
+  try {  // attempt to boot the server with an invalid DATABASE_URL
+    server1.register({ register: require('../index.js') }, function(err) {
+      console.log(err); // this error is never reached as the assert is fatal!
+    });
+  } catch (e) {
+    t.ok(e.toString().indexOf('Please set DATABASE_URL') > 1,
+      'Please set DATABASE_URL Env Variable');
+    t.end();
+  }
+});

--- a/test/startup_failure.test.js
+++ b/test/startup_failure.test.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var Hapi = require('hapi');
+require('decache')('../index.js'); // we have to "un-require" the plugin
 
 /************************* TESTS ***************************/
 test("server.register plugin fails when DATABASE_URL undefined", function (t) {


### PR DESCRIPTION
Instead of connecting to PostgreSQL _inside_ the plugin, we connect _before_ registering the plugin.
That way, we re-use the _same_ connection (pool) for _all_ routes and _never_ close it until we `server.stop` ...

fixes https://github.com/dwyl/hapi-postgres-connection/issues/10
