### PR TITLE
Make connection string compatible with pg-pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "4.5.0"
+  - "node"
+  - "4"
+  - "6"
+  - "8"
 sudo: false
 before_script:
   - psql -c 'create database test;' -U postgres
@@ -12,4 +15,4 @@ env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost/test
 addons:
-  postgresql: "9.6"
+  postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.4.0"
+  - "4.5.0"
 sudo: false
 before_script:
   - psql -c 'create database test;' -U postgres
@@ -12,4 +12,4 @@ env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost/test
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var PG_CON = []; // this "global" is local to the plugin.
 var run_once = false;
 
 // create a pool
-var pool = new pg.Pool(process.env.DATABASE_URL);
+var pool = new pg.Pool({connectionString: process.env.DATABASE_URL});
 
 // connection using created pool
 pool.connect(function(err, client, done) {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ exports.register = function(server, options, next) {
       });
     }
     if(PG_CON.length === 0) {
-      pg.connect(process.env.DATABASE_URL, function(err, client, done) {
+      pool.connect(function(err, client, done) {
+        assert(!err, pkg.name + 'ERROR Connecting to PostgreSQL!');
         PG_CON.push({ client: client, done: done});
         assign_connection(request, reply);
       });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run create && ./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/connection_error.test.js  | node_modules/tap-spec/bin/cmd.js && npm run perf"
   },
   "dependencies": {
-    "pg": "^6.4.1"
+    "pg": "^7.1.0"
   },
   "devDependencies": {
     "decache": "^4.0.0",

--- a/test/_create_test_db.js
+++ b/test/_create_test_db.js
@@ -7,7 +7,7 @@ var pg = require('pg');
 var assert = require('assert');
 
 function create_tables (callback) {
-  var pool = new pg.Pool(process.env.DATABASE_URL);
+  var pool = new pg.Pool({connectionString: process.env.DATABASE_URL});
   pool.connect( function(err, client) {
     assert(!err); // if db connection fails then EXPLODE!!
     var file = require('path').resolve(__dirname + '/test_db_setup.sql');

--- a/test/_create_test_db.js
+++ b/test/_create_test_db.js
@@ -25,7 +25,7 @@ function create_tables (callback) {
 
 test('Create "users" table in test database', function (t) {
   create_tables(function (err, data) {
-    t.equal(data.command, 'INSERT', 'DB Table Created & Test Data Inserted');
+    t.equal(data[data.length-1].command, 'INSERT', 'DB Table Created & Test Data Inserted');
     t.end();
   })
 });


### PR DESCRIPTION
The update to make hapi-postgres-connection compatible with latest postgres module broke for me. As far as I can tell, if you are using pg-pool you can no longer pass a single connection url string to have it connect, per https://github.com/brianc/node-pg-pool/blob/master/README.md

Adding the database connection url to the connectionString parameter seems like the simple fix to me. 

Tested using the latest pg 6.4.1 and pg-pool 1.8.