### PR TITLE
Add the option of connecting using SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ or why this is a *good idea*
 (*hard-coding values in your app is a really bad idea...*)  
 please see: https://github.com/dwyl/learn-environment-variables
 
+### *Optional* Environment Variable: `DATABASE_SSL`
+If your database connection requires the use of SSL, you can set `DATABASE_SSL` environment
+variable to true and the pool connection will be done accordingly. This is required
+(for example) by databases hosted on [*Heroku*]
+(https://devcenter.heroku.com/articles/heroku-postgresql#heroku-postgres-ssl).
+
 ## *Q*: Don't We need to Close the Postgres Connection?
 
 ***A***: No! The plugin handles closing the connection for you!

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var PG_CON = []; // this "global" is local to the plugin.
 var run_once = false;
 
 // create a pool
-var pool = new pg.Pool({connectionString: process.env.DATABASE_URL});
+var pool = new pg.Pool({connectionString: process.env.DATABASE_URL, ssl: process.env.DATABASE_SSL || false});
 
 // connection using created pool
 pool.connect(function(err, client, done) {


### PR DESCRIPTION
Add the ability of setting DATABASE_SSL environment variable to true for establishing a connection using SSL. 

This will potentially fix https://github.com/dwyl/hapi-postgres-connection/issues/34, I was getting the same error and the fix worked for me.